### PR TITLE
fix: Use a different `std::thread::Thread` for `Stdin` IO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,6 +1630,7 @@ dependencies = [
  "colored",
  "config",
  "dirs",
+ "futures",
  "humantime",
  "miette",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ color-print = "0.3.6"
 colored = "2.1.0"
 config = "0.14.1"
 dirs = "5.0.1"
+futures = "0.3.31"
 humantime = "2.1.0"
 miette = { version = "7.2.0", features = ["fancy"] }
 pin-project-lite = "0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -349,7 +349,7 @@ pub enum RecordsOut {
 }
 
 impl RecordsIn {
-    pub async fn into_lines_stream(
+    pub async fn into_reader(
         &self,
     ) -> std::io::Result<Pin<Box<dyn Stream<Item = std::io::Result<String>> + Send>>> {
         match self {
@@ -717,7 +717,7 @@ async fn run() -> Result<(), S2CliError> {
             let stream_client = StreamClient::new(client_config, basin, stream);
             let append_input_stream = RecordStream::new(
                 input
-                    .into_lines_stream()
+                    .into_reader()
                     .await
                     .map_err(|e| S2CliError::RecordReaderInit(e.to_string()))?,
             );
@@ -1008,5 +1008,5 @@ async fn run() -> Result<(), S2CliError> {
         }
     };
 
-    std::process::exit(0);
+    Ok(())
 }


### PR DESCRIPTION
See: https://docs.rs/tokio/latest/tokio/io/struct.Stdin.html

> This handle is best used for non-interactive uses, such as when a
> file is piped into the application. For technical reasons, stdin is
> implemented by using an ordinary blocking read on a separate thread,
> and it is impossible to cancel that read. This can make shutdown of
> the runtime hang until the user presses enter.
>
> For interactive uses, it is recommended to spawn a thread dedicated to
> user input and use blocking IO directly in that thread.

Resolves: #61